### PR TITLE
Fix NSLog NSDictionary memory flood.

### DIFF
--- a/Classes/MultibyteDescription.m
+++ b/Classes/MultibyteDescription.m
@@ -118,7 +118,7 @@
                 [mStr appendFormat:@"%@ = %@;\n", key, [obj description]];
             }
         }];
-        for (int i = 0; i < indent - 1; i++) {
+        for (int i = 0; indent > 0 && i < indent - 1; i++) {
             [mStr appendString:@"    "];
         }
         [mStr appendString:@"}"];


### PR DESCRIPTION
when indent equal to 0, NSLog NSDictionary will make a memory flood while (i < indent -1) always be true.
